### PR TITLE
Employ user hooks to map Stanford's pretrained word embeddings to Spacy's token vectors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-spacy-nightly>=2.1.0a9
+spacy>=2.1.0
 stanfordnlp>=0.1.0,<0.2.0
 # Development dependencies
 pytest>=4.0.0,<5.0.0

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def setup_package():
         version=about["__version__"],
         license=about["__license__"],
         packages=find_packages(),
-        install_requires=["spacy-nightly>=2.1.0a9", "stanfordnlp>=0.1.0,<0.2.0"],
+        install_requires=["spacy>=2.1.0", "stanfordnlp>=0.1.0,<0.2.0"],
         python_requires=">=3.6",
         entry_points={
             "spacy_languages": [

--- a/spacy_stanfordnlp/language.py
+++ b/spacy_stanfordnlp/language.py
@@ -57,7 +57,6 @@ class StanfordNLPLanguage(Language):
         return self.svecs.vocab.unit2id(token.text) != UNK_ID
 
 
-
 def get_defaults(lang):
     """Get the language-specific defaults, if available in spaCy. This allows
     using lexical attribute getters that depend on static language data, e.g.
@@ -152,7 +151,6 @@ class Tokenizer(object):
             doc.is_tagged = True
         if any(deps):
             doc.is_parsed = True
-
         return doc
 
     def get_tokens_with_heads(self, snlp_doc):


### PR DESCRIPTION
Since StanfordNLP's pretrained word embeddings are already loaded into memory (I think), this seems to be the easiest way to acccess them. Another option, I guess, would be to load them as external vectors into Spacy's vocabulary, but not sure if there would be any advantage, given that it would also duplicate memory.

Note, PR also updates the Spacy dependency from 2.1.0 alpha (nightly) to 2.1.0 stable version.