### PR TITLE
Tokenizer pipe() method for duck-type compatibility with Spacy Tokenizer

### DIFF
--- a/spacy_stanfordnlp/language.py
+++ b/spacy_stanfordnlp/language.py
@@ -178,6 +178,15 @@ class Tokenizer(object):
             doc.is_parsed = True
         return doc
 
+    def pipe(self, texts):
+        """Tokenize a stream of texts.
+
+        texts: A sequence of unicode texts.
+        YIELDS (Doc): A sequence of Doc objects, in order.
+        """
+        for text in texts:
+            yield self(text)
+
     def get_tokens_with_heads(self, snlp_doc):
         """Flatten the tokens in the StanfordNLP Doc and extract the token indices
         of the sentence start tokens to set is_sent_start.


### PR DESCRIPTION
Useful in case some code explicitly calls `nlp.tokenizer.pipe()`, as `spacymoji.Emoji`'s constructor does for example.