### PR TITLE
Allow passing of empty text strings

### DIFF
--- a/spacy_stanfordnlp/about.py
+++ b/spacy_stanfordnlp/about.py
@@ -1,5 +1,5 @@
 __title__ = "spacy-stanfordnlp"
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 __summary__ = "Use the latest StanfordNLP research models directly in spaCy"
 __uri__ = "https://explosion.ai"
 __author__ = "Ines Montani"

--- a/spacy_stanfordnlp/language.py
+++ b/spacy_stanfordnlp/language.py
@@ -6,6 +6,7 @@ from spacy.util import get_lang_class
 
 from stanfordnlp.models.common.vocab import UNK_ID
 from stanfordnlp.models.common.pretrain import Pretrain
+from stanfordnlp.pipeline.doc import Document
 
 import numpy
 import re
@@ -130,11 +131,12 @@ class Tokenizer(object):
         text (unicode): The text to process.
         RETURNS (spacy.tokens.Doc): The spaCy Doc object.
         """
-        snlp_doc = self.snlp(text)
+        snlp_doc = self.snlp(text) if text else Document("")
         text = snlp_doc.text
         tokens, heads = self.get_tokens_with_heads(snlp_doc)
         if not len(tokens):
-            raise ValueError("No tokens available.")
+            return Doc(self.vocab)
+
         words = []
         spaces = []
         pos = []


### PR DESCRIPTION
For compatibility with native Spacy language class allow passing of empty text strings to process. This will produce 0-length docs (no tokens) rather than raising an exception.

You may want to squash the commits as there were a couple of unnecessary merge actions ...